### PR TITLE
Healthcheck issue

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -75,7 +75,13 @@ module.exports = function(task) {
 		}
 	}
 
-	task.on('tuple', _incrementReceivedCount) //Bolt mode
+	function _syncAfterHeartbeat(){
+		_incrementReceivedCount();
+		collector.sync();
+	}
+
+	task.on('__heartbeat', _syncAfterHeartbeat) //Bolt keep-alive
+		.on('tuple', _incrementReceivedCount) //Bolt mode
 		.on('next', _incrementReceivedCount)  //Spout mode
 		.on('tasks', _returnTaskArray)
 

--- a/lib/localcluster.js
+++ b/lib/localcluster.js
@@ -61,7 +61,8 @@ LocalCluster.prototype._start = function() {
 			zookeeper,
 			self._startServer('nimbus', 6627),
 			self._startServer('drpc', 3772),
-			self._startServer('supervisor')
+			self._startServer('supervisor'),
+			self._startServer('ui')
 		]
 	}).spread(function(zookeeper, nimbus, drpc, supervisor) {
 		self._servers = [zookeeper, nimbus, drpc, supervisor]

--- a/lib/task.js
+++ b/lib/task.js
@@ -8,6 +8,8 @@ module.exports = function() {
 			this.emit('tasks', data)
 		} else if (data.command) {
 			this.emit(data.command, data)
+		} else if (data.stream == '__heartbeat') {
+			this.emit('__heartbeat', data)
 		} else {
 			this.emit('tuple', data)
 		}

--- a/test/collector.spec.js
+++ b/test/collector.spec.js
@@ -110,6 +110,20 @@ describe('collector', function() {
 
 	})
 
+	describe('heartbeat', function() {
+		it('emits a sync command when a heartbeat message is received', function(done){
+			var task = createTask()
+			es.readArray([{stream: '__heartbeat'}])
+				.pipe(task)
+				.pipe(es.writeArray(function(err, array) {
+					array.should.eql([
+						{command: 'sync'},
+					])
+					done()
+				}))
+		})
+	})
+
 	describe('end', function() {
 
 		it('ends the stream after all tuples have been acked or failed', function(done) {

--- a/test/task.spec.js
+++ b/test/task.spec.js
@@ -35,6 +35,16 @@ describe('task', function() {
 			})
 	})
 
+	it('emits a heartbeat for heartbeat messages', function(done){
+		var task = createTask()
+		es.readArray([{stream: '__heartbeat'}])
+			.pipe(task)
+			.on('__heartbeat', function(data) {
+				data.should.eql({stream: '__heartbeat'})
+				done()
+			})
+	})
+
 	it('emits an event for each tuple', function(done) {
 		var task = createTask()
 		es.readArray([{id:1}])


### PR DESCRIPTION
Hi,

Thanks a lot for this project. I'm still learning the basics, but I've hit an issue when running any example included or my own code. I'm using kafka 0.8.1.1 with storm 0.9.3.

Notice in the following output from running `node examples/wordcount.js localhost` that the `splitsentence` emit just stops (about 2 sec' after starting):
```
2015-01-04T17:12:42.901+0200 b.s.d.task [INFO] Emitting: splitsentence default ["seven"]
2015-01-04T17:12:42.901+0200 b.s.d.task [INFO] Emitting: splitsentence default ["dwarfs"]
2015-01-04T17:12:42.998+0200 b.s.d.task [INFO] Emitting: randomsentence default ["i am at two with nature"]
2015-01-04T17:12:42.999+0200 b.s.d.executor [INFO] Processing received message source: randomsentence:2, stream: default, id: {}, ["i am at two with nature"]
2015-01-04T17:12:43.000+0200 b.s.d.task [INFO] Emitting: splitsentence default ["i"]
2015-01-04T17:12:43.001+0200 b.s.d.task [INFO] Emitting: splitsentence default ["am"]
2015-01-04T17:12:43.001+0200 b.s.d.task [INFO] Emitting: splitsentence default ["at"]
2015-01-04T17:12:43.002+0200 b.s.d.task [INFO] Emitting: splitsentence default ["two"]
2015-01-04T17:12:43.002+0200 b.s.d.task [INFO] Emitting: splitsentence default ["with"]
2015-01-04T17:12:43.003+0200 b.s.d.task [INFO] Emitting: splitsentence default ["nature"]
2015-01-04T17:12:43.099+0200 b.s.d.task [INFO] Emitting: randomsentence default ["the cow jumped over the moon"]
2015-01-04T17:12:43.100+0200 b.s.d.executor [INFO] Processing received message source: randomsentence:2, stream: default, id: {}, ["the cow jumped over the moon"]
2015-01-04T17:12:43.201+0200 b.s.d.task [INFO] Emitting: randomsentence default ["an apple a day keeps the doctor away"]
2015-01-04T17:12:43.201+0200 b.s.d.executor [INFO] Processing received message source: randomsentence:2, stream: default, id: {}, ["an apple a day keeps the doctor away"]
2015-01-04T17:12:43.302+0200 b.s.d.task [INFO] Emitting: randomsentence default ["i am at two with nature"]
2015-01-04T17:12:43.303+0200 b.s.d.executor [INFO] Processing received message source: randomsentence:2, stream: default, id: {}, ["i am at two with nature"]
2015-01-04T17:12:43.404+0200 b.s.d.task [INFO] Emitting: randomsentence default ["an apple a day keeps the doctor away"]
2015-01-04T17:12:43.404+0200 b.s.d.executor [INFO] Processing received message source: randomsentence:2, stream: default, id: {}, ["an apple a day keeps the doctor away"]
```

Here's an output from running my own bolt showing the HB data coming in.
```
2015-01-04T15:28:50.439+0200 b.s.d.worker [INFO] Worker 58022f18-8974-4f53-a4c0-8fae98d593f8 for storm kafka-consumer-28-1420378126 on db5e5f67-1582-4591-b2a6-2bcf86081d11:6703 has finished loading
2015-01-04T15:28:50.499+0200 b.s.t.ShellBolt [INFO] Launched subprocess with pid 14547
2015-01-04T15:28:50.502+0200 b.s.t.ShellBolt [INFO] Start checking heartbeat...
2015-01-04T15:28:50.502+0200 b.s.d.executor [INFO] Prepared bolt printBolt:(3)
2015-01-04T15:28:50.528+0200 b.s.s.ShellSpout [INFO] Launched subprocess with pid 14548
2015-01-04T15:28:50.529+0200 b.s.d.executor [INFO] Opened spout kafkaSpout:(2)
2015-01-04T15:28:50.530+0200 b.s.d.executor [INFO] Activating spout kafkaSpout:(2)
2015-01-04T15:28:50.530+0200 b.s.s.ShellSpout [INFO] Start checking heartbeat...
2015-01-04T15:28:52.503+0200 b.s.t.ShellBolt [INFO] ShellLog pid:14547, name:printBolt data!!!
2015-01-04T15:28:52.503+0200 b.s.t.ShellBolt [INFO] ShellLog pid:14547, name:printBolt {"id":"3540837237882002241","stream":"__heartbeat","comp":null,"tuple":[],"task":-1}
2015-01-04T15:28:52.503+0200 b.s.t.ShellBolt [INFO] ShellLog pid:14547, name:printBolt HEARTBEAT!!!!
2015-01-04T15:29:20.536+0200 b.s.s.ShellSpout [ERROR] Halting process: ShellSpout died.
java.lang.RuntimeException: subprocess heartbeat timeout
	at backtype.storm.spout.ShellSpout$SpoutHeartbeatTimerTask.run(ShellSpout.java:255) [storm-core-0.9.3.jar:0.9.3]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_65]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304) [na:1.7.0_65]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178) [na:1.7.0_65]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [na:1.7.0_65]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_65]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_65]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_65]
2015-01-04T15:29:20.537+0200 b.s.d.executor [ERROR] 
java.lang.RuntimeException: subprocess heartbeat timeout
	at backtype.storm.spout.ShellSpout$SpoutHeartbeatTimerTask.run(ShellSpout.java:255) [storm-core-0.9.3.jar:0.9.3]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_65]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304) [na:1.7.0_65]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178) [na:1.7.0_65]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [na:1.7.0_65]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_65]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [na:1.7.0_65]
	at java.lang.Thread.run(Thread.java:745) [na:1.7.0_65]
```