### PR TITLE
Local Topology hangs if ```storm``` on PATH is a symbolic link

### DIFF
--- a/lib/localcluster.js
+++ b/lib/localcluster.js
@@ -91,6 +91,7 @@ LocalCluster.prototype._getLogDirectory = function() {
 		var searchPath = searchPaths[i]
 		var stormBin = path.join(searchPath, 'storm')
 		if (fs.existsSync(stormBin)) {
+			searchPath = path.dirname(fs.realpathSync(stormBin))
 			return path.resolve(searchPath, '../logs')
 		}
 	}


### PR DESCRIPTION
The local cluster in debug mode tails the storm log files. It waits on startup for the 'log' folder to exist in the storm installation directory. The problem comes the assumption that the installation directory can be found from ```storm``` on the PATH without resolving symlinks.