### PR TITLE
Do not use absolute path of node

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -19,7 +19,8 @@ function javacomponent(className) {
 function shellcomponent() {
 	return new ttypes.ComponentObject({
 		shell: new ttypes.ShellComponent({
-			execution_command: process.argv[0],
+			//execution_command: process.argv[0],
+      execution_command: 'node',
 			script: util.topologyScript()
 		})
 	})


### PR DESCRIPTION
Hello there. I have tried this package and found it amazing!
However, run script with `process.argv[0]` does not make sense because the value is always absolute path on the submitter machine. For example, I am using nvm on local machine, so the value would be `$HOME/.nvm/version/vx.x.x/bin/node`, but it was `/usr/local/bin/node` on the storm supervisor server.
I hope this PR could fix this problem, and I have tested it using docker.

BTW, I have created a Dockerfile for the test environment [here](https://github.com/crzidea/docker-node-storm).